### PR TITLE
Replace the emoji in an error message

### DIFF
--- a/web/src/page_tracker/app.py
+++ b/web/src/page_tracker/app.py
@@ -13,7 +13,7 @@ def index():
         page_views = redis().incr("page_views")
     except RedisError:
         app.logger.exception("Redis error")  # pylint: disable=E1101
-        return "Sorry, something went wrong \N{pensive face}", 500
+        return "Sorry, something went wrong \N{thinking face}", 500
     else:
         return f"This page has been seen {page_views} times."
 

--- a/web/test/unit/test_app.py
+++ b/web/test/unit/test_app.py
@@ -31,4 +31,4 @@ def test_should_handle_redis_connection_error(mock_redis, http_client):
 
     # Then
     assert response.status_code == 500
-    assert response.text == "Sorry, something went wrong \N{pensive face}"
+    assert response.text == "Sorry, something went wrong \N{thinking face}"


### PR DESCRIPTION
should fail due to automated test